### PR TITLE
Any 2.* version of zend-xmlrpc is now accepted instead of just 2.3.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "zendframework/zend-xmlrpc": "2.3.*",
+        "zendframework/zend-xmlrpc": "~2.3",
         "zendframework/zendxml": "1.0.*"
     },
     "autoload": {


### PR DESCRIPTION
This makes it easier for composer to resolve to an installable set of packages. (Which one of my current projects fails to do because of the `2.3.*` requirement.)

This should be safe to do because ZF uses [semver](http://semver.org/), and therefore minor (x.Y.z) releases do not introduce breaking changes.